### PR TITLE
Make create be no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@
 //! # fn main() {}
 //! ```
 
+#![cfg(not(test))] #![no_std]
+
 #![doc(html_root_url = "http://alexcrichton.com/cfg-if")]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! # fn main() {}
 //! ```
 
-#![cfg(not(test))] #![no_std]
+#![no_std]
 
 #![doc(html_root_url = "http://alexcrichton.com/cfg-if")]
 #![deny(missing_docs)]
@@ -69,7 +69,7 @@ macro_rules! __cfg_if_apply {
 mod tests {
     cfg_if! {
         if #[cfg(test)] {
-            use std::option::Option as Option2;
+            use core::option::Option as Option2;
             fn works1() -> Option2<u32> { Some(1) }
         } else {
             fn works1() -> Option<u32> { None }


### PR DESCRIPTION
The regular portion of the crate doesn't need anything from std
so turn off std for non-test. This allows this to be used from
projects which are also no_std.