### PR TITLE
Allow blocks without else.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,19 @@ macro_rules! cfg_if {
             $( ( ($($meta),*) ($($it)*) ), )*
             ( () ($($it2)*) ),
         }
+    };
+    (
+        if #[cfg($($i_met:meta),*)] { $($i_it:item)* }
+        $(
+            else if #[cfg($($e_met:meta),*)] { $($e_it:item)* }
+        )*
+    ) => {
+        __cfg_if_items! {
+            () ;
+            ( ($($i_met),*) ($($i_it)*) ),
+            $( ( ($($e_met),*) ($($e_it)*) ), )*
+            ( () () ),
+        }
     }
 }
 
@@ -94,10 +107,27 @@ mod tests {
         }
     }
 
+    cfg_if! {
+        if #[cfg(test)] {
+            use core::option::Option as Option3;
+            fn works4() -> Option3<u32> { Some(1) }
+        }
+    }
+
+    cfg_if! {
+        if #[cfg(foo)] {
+            fn works5() -> bool { false }
+        } else if #[cfg(test)] {
+            fn works5() -> bool { true }
+        }
+    }
+
     #[test]
     fn it_works() {
         assert!(works1().is_some());
         assert!(works2());
         assert!(works3());
+        assert!(works4().is_some());
+        assert!(works5());
     }
 }


### PR DESCRIPTION
It doesn't seem immediately obvious from the documentation that you can't do a block without an else branch, so, I added that functionality.