### PR TITLE
Put `#[cfg]` in backticks.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A macro for defining #[cfg] if-else statements.
+//! A macro for defining `#[cfg]` if-else statements.
 //!
 //! The macro provided by this crate, `cfg_if`, is similar to the `if/elif` C
 //! preprocessor macro by allowing definition of a cascade of `#[cfg]` cases,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! preprocessor macro by allowing definition of a cascade of `#[cfg]` cases,
 //! emitting the implementation which matches first.
 //!
-//! This allows you to conveniently provide a long list #[cfg]'d blocks of code
+//! This allows you to conveniently provide a long list `#[cfg]`'d blocks of code
 //! without having to rewrite each clause multiple times.
 //!
 //! # Example


### PR DESCRIPTION
The bare `[cfg]` makes rustdoc nightly complain.