### PR TITLE
Fix doc warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-//! A macro for defining #[cfg] if-else statements.
+//! A macro for defining #\[cfg\] if-else statements.
 //!
 //! The macro provided by this crate, `cfg_if`, is similar to the `if/elif` C
 //! preprocessor macro by allowing definition of a cascade of `#[cfg]` cases,
 //! emitting the implementation which matches first.
 //!
-//! This allows you to conveniently provide a long list #[cfg]'d blocks of code
+//! This allows you to conveniently provide a long list #\[cfg\]'d blocks of code
 //! without having to rewrite each clause multiple times.
 //!
 //! # Example


### PR DESCRIPTION
```
 Documenting cfg-if v0.1.3 (file:///home/humbug/cfg-if)
warning: `[cfg]` cannot be resolved, ignoring it...
 --> src/lib.rs:1:28
  |
1 | //! A macro for defining #[cfg] if-else statements.
  |                            ^^^ cannot be resolved, ignoring
  |
  = note: #[warn(intra_doc_link_resolution_failure)] on by default
  = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[cfg]` cannot be resolved, ignoring it...
 --> src/lib.rs:7:59
  |
7 | //! This allows you to conveniently provide a long list #[cfg]'d blocks of code
  |                                                           ^^^ cannot be resolved, ignoring
  |
  = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

    Finished dev [unoptimized + debuginfo] target(s) in 0.22s
```

$ rustc --version
rustc 1.28.0-nightly (01cc982e9 2018-06-24)