### PR TITLE
Get it to work with Rust 2018 module changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! cfg_if {
     // match if/else chains with a final `else`
     ($(


### PR DESCRIPTION
Currently `cfg-if` is unusable with the Rust 2018 module changes ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=b95b9cb22378dfda39f4e1b02dcf1c19)).

As per [this internals thread](https://internals.rust-lang.org/t/macros-1-2-stabilization-status-update/7917), the recommended solution to maintain Rust 2015 compatibility is to add the `#[macro_export(local_inner_macros)]` attribute to the macro.

To test that the fix works, create `tests/rust2018.rs` with the following content:
```
cfg_if::cfg_if! {
    if #[cfg(foo)] {
        struct Foo;
    }
}
```

Then, run `cargo +beta test` or `cargo +nightly test`. The test case isn't included in the PR because it doesn't compile on stable Rust.