### PR TITLE
Support no_core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ matrix:
 script:
   - cargo build --verbose
   - cargo test --verbose
+  # Tests with no_core
+  - |
+    if [ "${TRAVIS_RUST_VERSION}" == "nightly" ]; then
+      cargo build --verbose --no-default-features
+    fi
+
 notifications:
   email:
     on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfg-if"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -15,3 +15,7 @@ item that gets emitted.
 
 [badges]
 travis-ci = { repository = "alexcrichton/cfg-if" }
+
+[features]
+default = ["use_core"]
+use_core = []

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ item that gets emitted.
 cfg-if = "0.1"
 ```
 
+The `use_core` feature is enabled by default and builds the crate with libcore
+by using the `#![no_std]` attribute. When this feature is disabled, this crate
+is built without libcore support by using the `#![no_core]` attribute - this
+makes use of the `#![feature(no_core)]` and requires a nightly version of Rust.
+
 ## Example
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,11 +26,12 @@
 //! # fn main() {}
 //! ```
 
-#![no_std]
-
+#![cfg_attr(not(feature = "use_core"), feature(no_core))]
 #![doc(html_root_url = "https://docs.rs/cfg-if")]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
+#![cfg_attr(not(feature = "use_core"), no_core)]
+#![cfg_attr(feature = "use_core", no_std)]
 
 /// The main macro provided by this crate. See crate documentation for more
 /// information.


### PR DESCRIPTION
This PR adds a cargo feature for this crate called `use_core` - this feature is enabled by default and builds the library with libcore (using the `#![no_std]` attribute). 

When this feature is disabled, the crate is built with `#![no_core]` instead. 