### PR TITLE
Fix crate name in the contribution section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in `cfg-if` by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Contributions to `cfg-if` do not go to Serde!