### PR TITLE
lib: add lint to forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/cfg-if")]
+#![forbid(unsafe_code)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
This adds a lint to forbid unsafe code inside this crate, as there
is none currently. The explicit annotation is helpful for
safety-tracking utilities, like https://crates.io/crates/cargo-geiger.