### PR TITLE
Prohibit multiple predicates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,30 +34,30 @@
 macro_rules! cfg_if {
     // match if/else chains with a final `else`
     ($(
-        if #[cfg($($meta:meta),*)] { $($tokens:tt)* }
+        if #[cfg($meta:meta)] { $($tokens:tt)* }
     ) else * else {
         $($tokens2:tt)*
     }) => {
         $crate::cfg_if! {
             @__items
             () ;
-            $( ( ($($meta),*) ($($tokens)*) ), )*
+            $( ( ($meta) ($($tokens)*) ), )*
             ( () ($($tokens2)*) ),
         }
     };
 
     // match if/else chains lacking a final `else`
     (
-        if #[cfg($($i_met:meta),*)] { $($i_tokens:tt)* }
+        if #[cfg($i_met:meta)] { $($i_tokens:tt)* }
         $(
-            else if #[cfg($($e_met:meta),*)] { $($e_tokens:tt)* }
+            else if #[cfg($e_met:meta)] { $($e_tokens:tt)* }
         )*
     ) => {
         $crate::cfg_if! {
             @__items
             () ;
-            ( ($($i_met),*) ($($i_tokens)*) ),
-            $( ( ($($e_met),*) ($($e_tokens)*) ), )*
+            ( ($i_met) ($($i_tokens)*) ),
+            $( ( ($e_met) ($($e_tokens)*) ), )*
             ( () () ),
         }
     };


### PR DESCRIPTION
I noticed that `cfg-if` uses `$($meta:meta),*` to match `cfg` predicates:
https://github.com/alexcrichton/cfg-if/blob/f71bf60f212312faddee7da525fcf47daac66499/src/lib.rs#L37
https://github.com/alexcrichton/cfg-if/blob/f71bf60f212312faddee7da525fcf47daac66499/src/lib.rs#L51
https://github.com/alexcrichton/cfg-if/blob/f71bf60f212312faddee7da525fcf47daac66499/src/lib.rs#L53

That is redundant: multiple `cfg` predicates is not allowed by `rustc`, and specifying multiple predicates results in `#[cfg]`s that do not make sense in `else` parts. Also, mistakes can be easily made when there're many parentheses and commas in the `cfg` predicate.