### PR TITLE
Add expanded example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ fn main() {
     foo();
 }
 ```
+The `cfg_if!` block above is expanded to:
+```rust
+#[cfg(unix)]
+fn foo() { /* unix specific functionality */ }
+#[cfg(all(target_pointer_width = "32", not(unix)))]
+fn foo() { /* non-unix, 32-bit functionality */ }
+#[cfg(not(any(unix, target_pointer_width = "32")))]
+fn foo() { /* fallback implementation */ }        
+```
 
 # License
 


### PR DESCRIPTION
I think an expanded example goes a long ways to show what the macro actually does. Even if it seems like it should be obvious, well..., it wasn't obvious to me until I did this exercise. I assume no one will mind that I altered the macro output to its simplest form (e.g. `unix` instead of `all(unix)`).