### PR TITLE
More readable formatting and identifier names.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,56 +33,69 @@
 #[macro_export]
 macro_rules! cfg_if {
     // match if/else chains with a final `else`
-    ($(
-        if #[cfg($meta:meta)] { $($tokens:tt)* }
-    ) else * else {
-        $($tokens2:tt)*
-    }) => {
+    (
+        $(
+            if #[cfg( $i_meta:meta )] { $( $i_tokens:tt )* }
+        ) else+
+        else { $( $e_tokens:tt )* }
+    ) => {
         $crate::cfg_if! {
-            @__items
-            () ;
-            $( ( ($meta) ($($tokens)*) ), )*
-            ( () ($($tokens2)*) ),
+            @__items () ;
+            $(
+                (( $i_meta ) ( $( $i_tokens )* )) ,
+            )+
+            (() ( $( $e_tokens )* )) ,
         }
     };
 
     // match if/else chains lacking a final `else`
     (
-        if #[cfg($i_met:meta)] { $($i_tokens:tt)* }
+        if #[cfg( $i_meta:meta )] { $( $i_tokens:tt )* }
         $(
-            else if #[cfg($e_met:meta)] { $($e_tokens:tt)* }
+            else if #[cfg( $e_meta:meta )] { $( $e_tokens:tt )* }
         )*
     ) => {
         $crate::cfg_if! {
-            @__items
-            () ;
-            ( ($i_met) ($($i_tokens)*) ),
-            $( ( ($e_met) ($($e_tokens)*) ), )*
-            ( () () ),
+            @__items () ;
+            (( $i_meta ) ( $( $i_tokens )* )) ,
+            $(
+                (( $e_meta ) ( $( $e_tokens )* )) ,
+            )*
         }
     };
 
     // Internal and recursive macro to emit all the items
     //
-    // Collects all the negated cfgs in a list at the beginning and after the
-    // semicolon is all the remaining items
-    (@__items ($($not:meta,)*) ; ) => {};
-    (@__items ($($not:meta,)*) ; ( ($($m:meta),*) ($($tokens:tt)*) ), $($rest:tt)*) => {
+    // Collects all the previous cfgs in a list at the beginning, so they can be
+    // negated. After the semicolon is all the remaining items.
+    (@__items ( $( $_:meta , )* ) ; ) => {};
+    (
+        @__items ( $( $no:meta , )* ) ;
+        (( $( $yes:meta )? ) ( $( $tokens:tt )* )) ,
+        $( $rest:tt , )*
+    ) => {
         // Emit all items within one block, applying an appropriate #[cfg]. The
-        // #[cfg] will require all `$m` matchers specified and must also negate
+        // #[cfg] will require all `$yes` matchers specified and must also negate
         // all previous matchers.
-        #[cfg(all($($m,)* not(any($($not),*))))] $crate::cfg_if! { @__identity $($tokens)* }
+        #[cfg(all(
+            $( $yes , )?
+            not(any( $( $no ),* ))
+        ))]
+        $crate::cfg_if! { @__identity $( $tokens )* }
 
         // Recurse to emit all other items in `$rest`, and when we do so add all
-        // our `$m` matchers to the list of `$not` matchers as future emissions
+        // our `$yes` matchers to the list of `$no` matchers as future emissions
         // will have to negate everything we just matched as well.
-        $crate::cfg_if! { @__items ($($not,)* $($m,)*) ; $($rest)* }
+        $crate::cfg_if! {
+            @__items ( $( $no , )* $( $yes , )? ) ;
+            $( $rest , )*
+        }
     };
 
     // Internal macro to make __apply work out right for different match types,
-    // because of how macros matching/expand stuff.
-    (@__identity $($tokens:tt)*) => {
-        $($tokens)*
+    // because of how macros match/expand stuff.
+    (@__identity $( $tokens:tt )* ) => {
+        $( $tokens )*
     };
 }
 


### PR DESCRIPTION
This macro provides a a great example for developers
learning macros to study. It's easy to discover, since
libstd and many other crates depend on it, and the
macro itself illustrates a number of useful concepts.
This commit reformats some code to make the brackets
easier to see, and renames a few identifiers for clarity.

Additionally, the `+` and `?` repetition quantifiers have
been used where appropriate instead of `*`, and an extra
`( () () )` item has been removed, which had no effect.