### PR TITLE
Document the minimum supported Rust version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        # NOTE: 1.32 is minimum supported Rust version
+        rust: [1.32, stable, beta, nightly]
     steps:
       - uses: actions/checkout@master
       - name: Install Rust Stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,18 @@ parameters. Structured like an if-else chain, the first matching branch is the
 item that gets emitted.
 """
 edition = "2018"
+# Require Rust >= 1.32, which added the `?` repetition operator
+#
+# See here: https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html#macro-improvements
+#
+# NOTE: This field was added in Rust 1.56.
+# On older versions this will do nothing and display a warning
+#
+# To bump the MSRV:
+# 1. Update this fields
+# 2. Update the README
+# 3. Update github actions file
+rust-version = "1.32"
 
 [badges]
 travis-ci = { repository = "alexcrichton/cfg-if" }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ fn foo() { /* non-unix, 32-bit functionality */ }
 fn foo() { /* fallback implementation */ }        
 ```
 
+# Minimum Supported Rust Version
+This project supports [Rust 1.32](https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html) or later.
+
 # License
 
 This project is licensed under either of


### PR DESCRIPTION
Hi! I noticed the Minimum Supported Rust Version is not explicitly documented.

Currently the MSRV appears to be 1.32,
because of the support for `?` repetitions (I have tested it).

I have added this to Github Actions matrix to ensure compatibility.

