### PR TITLE
Revert "Remove `@__identity` rule."

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ macro_rules! cfg_if {
             $( $yes , )?
             not(any( $( $no ),* ))
         ))]
-        $( $tokens )*
+        $crate::cfg_if! { @__identity $( $tokens )* }
 
         // Recurse to emit all other items in `$rest`, and when we do so add all
         // our `$yes` matchers to the list of `$no` matchers as future emissions
@@ -91,6 +91,12 @@ macro_rules! cfg_if {
             @__items ( $( $no , )* $( $yes , )? ) ;
             $( $rest , )*
         }
+    };
+
+    // Internal macro to make __apply work out right for different match types,
+    // because of how macros match/expand stuff.
+    (@__identity $( $tokens:tt )* ) => {
+        $( $tokens )*
     };
 }
 


### PR DESCRIPTION
This change created a regression.

This reverts commit 4d7a585e4d033280d3610c95aa0ea178444a3ff1.

Closes: https://github.com/rust-lang/cfg-if/issues/90